### PR TITLE
Remove Deprecated Functions and Libraries

### DIFF
--- a/fid.py
+++ b/fid.py
@@ -21,7 +21,7 @@ import numpy as np
 import os
 import gzip, pickle
 import tensorflow as tf
-from scipy.misc import imread
+from imageio import imread
 from scipy import linalg
 import pathlib
 import urllib
@@ -34,7 +34,7 @@ class InvalidFIDException(Exception):
 def create_inception_graph(pth):
     """Creates a graph from saved GraphDef file."""
     # Creates graph from saved graph_def.pb.
-    with tf.io.gfile.FastGFile( pth, 'rb') as f:
+    with tf.io.gfile.GFile( pth, 'rb') as f:
         graph_def = tf.compat.v1.GraphDef()
         graph_def.ParseFromString( f.read())
         _ = tf.import_graph_def( graph_def, name='FID_Inception_Net')


### PR DESCRIPTION
imread is now no longer present at scipy.misc, imageio is preferred.
tf.io.gfile.FastGFile() is now deprecated, tf.io.GFile() is preferred.

This enables the file imports from fid.py to run on Google Colab and subsequent tensorflow versions.